### PR TITLE
Add additional contributors

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   "contributors": [
     "Gen Edwards <gedwards@quickbase.com>",
     "Michael Harris <mharris@quickbse.com>",
-    "Nick Vanselow <nvanselow@quickbase.com>"
+    "Nick Vanselow <nvanselow@quickbase.com>",
+    "Danilo Castro <daniloster@gmail.com>"
   ],
   "license": "MIT",
   "private": false,


### PR DESCRIPTION
Unfortunately, it looks like I won't be able to get back to this project until late November or December. However, I should've made this change a while back.

@daniloster had this info in his current PR.  @dan-kez, @prevostc - If you would like to be added to the contributors list in the package.json, let me know or submit a PR and we will get that oversight fixed.

