### PR TITLE
track the position of each template expression so they don't get shuffled

### DIFF
--- a/src/tests/__snapshots__/cssNamespace.test.js.snap
+++ b/src/tests/__snapshots__/cssNamespace.test.js.snap
@@ -491,6 +491,75 @@ export default MyStyledComponent;
 "
 `;
 
+exports[`styled-components-css-namespace handles re-ordering of template expressions: handles re-ordering of template expressions 1`] = `
+"
+import styled from 'styled-components';
+
+/*
+  The PostCSS flattening pulls the &:hover and &:active out of the
+  main style block, placing it _after_ the main block. Therefore
+  the template expressions in those pseudo-class style blocks are
+  not in the same relative position in the final processed CSS
+  as they were in the original. The bug-fix tracks the _order_ of
+  the expressions, so that when they're inserted back into the
+  template each expression winds up in the correct position.
+ */
+
+export default styled.div\`
+  background: \${props => props.background};
+  border: 1px solid \${props => props.borderColor};
+  width: 100%;
+
+  \${props => props.styles};
+
+  &:hover {
+    border-color: \${props => props.hoverBorder};
+  }
+
+  &:active {
+    border-color: \${props => props.activeBorder};
+    \${props.activeStyles};
+  }
+
+  \${props => props.moreStyles};
+\`;
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import styled from 'styled-components';
+/*
+  The PostCSS flattening pulls the &:hover and &:active out of the
+  main style block, placing it _after_ the main block. Therefore
+  the template expressions in those pseudo-class style blocks are
+  not in the same relative position in the final processed CSS
+  as they were in the original. The bug-fix tracks the _order_ of
+  the expressions, so that when they're inserted back into the
+  template each expression winds up in the correct position.
+ */
+
+export default styled.div\`
+.class-wrapper .other-wrapper & {
+  background: \${props => props.background};
+  border: 1px solid \${props => props.borderColor};
+  width: 100%;
+
+  \${props => props.styles};
+
+  \${props => props.moreStyles};
+}
+
+  .class-wrapper .other-wrapper &:hover {
+    border-color: \${props => props.hoverBorder};
+  }
+
+  .class-wrapper .other-wrapper &:active {
+    border-color: \${props => props.activeBorder};
+    \${props.activeStyles};
+  }
+\`;
+"
+`;
+
 exports[`styled-components-css-namespace namespaces a style block with &&: namespaces a style block with && 1`] = `
 "
 const styled = { input() {} };

--- a/src/tests/cssNamespace.test.js
+++ b/src/tests/cssNamespace.test.js
@@ -146,6 +146,16 @@ pluginTester({
         __dirname,
         './fixtures/styled_component_without_trailing_semicolon.js'
       )
+    },
+    {
+      title: 'handles re-ordering of template expressions',
+      pluginOptions: {
+        cssNamespace: '.class-wrapper .other-wrapper'
+      },
+      fixture: path.join(
+        __dirname,
+        './fixtures/reordered-template-expressions.js'
+      )
     }
 
     /**

--- a/src/tests/fixtures/reordered-template-expressions.js
+++ b/src/tests/fixtures/reordered-template-expressions.js
@@ -1,0 +1,30 @@
+import styled from 'styled-components';
+
+/*
+  The PostCSS flattening pulls the &:hover and &:active out of the
+  main style block, placing it _after_ the main block. Therefore
+  the template expressions in those pseudo-class style blocks are
+  not in the same relative position in the final processed CSS
+  as they were in the original. The bug-fix tracks the _order_ of
+  the expressions, so that when they're inserted back into the
+  template each expression winds up in the correct position.
+ */
+
+export default styled.div`
+  background: ${props => props.background};
+  border: 1px solid ${props => props.borderColor};
+  width: 100%;
+
+  ${props => props.styles};
+
+  &:hover {
+    border-color: ${props => props.hoverBorder};
+  }
+
+  &:active {
+    border-color: ${props => props.activeBorder};
+    ${props.activeStyles};
+  }
+
+  ${props => props.moreStyles};
+`;


### PR DESCRIPTION
This PR fixes an issue that occurs when processing CSS that includes psuedo-classes that have embedded template literal expressions.

The PostCSS processing pulls the pseudo-classes out of the main style block into blocks following. This can lead to a situation where the expressions are put back into the CSS in the wrong order.

Example:

```js
export default styled.div`
  background: ${expr1};

  &:hover {
    ${expr2};
  }

  ${expr3};
`;
```

...will wind up as...

```js
export default styled.div`
&& {
  background: ${expr1};

  ${expr2}; /* wrong expression! */
}

&&:hover {
  ${expr3}; /* wrong expression! */
}
```

The fix tracks the expression sequence by including an index in the "fake expression" placeholder. Those indices are then used to make sure the expressions are re-inserted in the correct sequence in the final CSS template literal.
