### PR TITLE
Added validation for expressions ending with nothing instead of a ';'

### DIFF
--- a/src/tests/__snapshots__/cssNamespace.test.js.snap
+++ b/src/tests/__snapshots__/cssNamespace.test.js.snap
@@ -99,6 +99,34 @@ export default MyStyledComponent;
 "
 `;
 
+exports[`styled-components-css-namespace adds workspace to simple component with nested css: adds workspace to simple component with nested css 1`] = `
+"
+const styled = { div() {} };
+
+const padding = 'padding: 2px 2px 2px 2px;';
+
+const MyStyledComponent = styled.div\`
+  \${padding}
+\`;
+
+export default MyStyledComponent;
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+const styled = {
+  div() {}
+
+};
+const padding = 'padding: 2px 2px 2px 2px;';
+const MyStyledComponent = styled.div\`
+.class-wrapper .other-wrapper & {
+  \${padding}
+}
+\`;
+export default MyStyledComponent;
+"
+`;
+
 exports[`styled-components-css-namespace does not add extra selectors to child helper styles: does not add extra selectors to child helper styles 1`] = `
 "
 const styled = { div() {} };

--- a/src/tests/cssNamespace.test.js
+++ b/src/tests/cssNamespace.test.js
@@ -156,6 +156,16 @@ pluginTester({
         __dirname,
         './fixtures/reordered-template-expressions.js'
       )
+    },
+    {
+      title: 'adds workspace to simple component with nested css',
+      pluginOptions: {
+        cssNamespace: '.class-wrapper .other-wrapper'
+      },
+      fixture: path.join(
+        __dirname,
+        './fixtures/simple_composed_styled_component.js'
+      )
     }
 
     /**

--- a/src/tests/fixtures/simple_composed_styled_component.js
+++ b/src/tests/fixtures/simple_composed_styled_component.js
@@ -1,0 +1,9 @@
+const styled = { div() {} };
+
+const padding = 'padding: 2px 2px 2px 2px;';
+
+const MyStyledComponent = styled.div`
+  ${padding}
+`;
+
+export default MyStyledComponent;

--- a/src/visitors/cssNamespace.js
+++ b/src/visitors/cssNamespace.js
@@ -81,7 +81,9 @@ export default (path, state) => {
           rawValueWithoutWhiteSpace.endsWith('{') ||
           rawValueWithoutWhiteSpace.endsWith('}') ||
           rawValueWithoutWhiteSpace.endsWith(';')) &&
-        (!nextQuasi || (nextQuasi && nextQuasi.value.raw.startsWith(';')))
+        (!nextQuasi ||
+          (nextQuasi.value.raw.startsWith(';') ||
+            nextQuasi.value.raw.trim() === ''))
       ) {
         return `${rawValue}${EXPRESSION}-${i}: ${FAKE_VALUE}`;
       }


### PR DESCRIPTION
A better solution would be appreciated, I don't really know the edge cases that may fail.

It will get #46 fixed.